### PR TITLE
fix: add output path for comp caching

### DIFF
--- a/packages/gatsby-plugin/package.json
+++ b/packages/gatsby-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nrwl/gatsby",
-  "version": "1000.0.0",
+  "version": "0.951.0",
   "description": "Gatsby Plugin for Nx",
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin/src/schematics/application/application.ts
+++ b/packages/gatsby-plugin/src/schematics/application/application.ts
@@ -134,6 +134,7 @@ function addProject(options: NormalizedSchema): Rule {
     architect.build = {
       builder: '@nrwl/gatsby:build',
       options: {
+        outputPath: `${options.projectRoot}/public`,
         uglify: true,
         color: true,
         profile: false,

--- a/packages/gatsby-plugin/src/utils/versions.ts
+++ b/packages/gatsby-plugin/src/utils/versions.ts
@@ -1,7 +1,7 @@
-export const nxVersion = '9.4.5';
+export const nxVersion = '9.5.1';
 export const angularDevkitSchematics = '9.1.7';
 
-export const gatsbyVersion = '2.20.24';
+export const gatsbyVersion = '2.23.18';
 export const gatsbyImageVersion = '2.2.39';
 export const gatsbyPluginManifestVersion = '2.2.39';
 export const gatsbyPluginOfflineVersion = '3.0.32';


### PR DESCRIPTION
Right now the `outputPath` is not in the workspace.json because it is not being used. Rather the build is placed inside the `public` dir within the gatsby app.

Quickly talked to @maxkoretskyi & @jaysoo and apparently there were some edge cases that caused issues with moving the output to `dist` (as all other Nx projects do). Worth investigating and also taking into consideration #20 .

This PR just adds the `outputPath` option to the project configuration s.t. the Nx computational cache works properly.