### PR TITLE
fix: Restore path to gatsby-cli fix

### DIFF
--- a/packages/gatsby-plugin/src/builders/build/builder.ts
+++ b/packages/gatsby-plugin/src/builders/build/builder.ts
@@ -43,7 +43,7 @@ export function runGatsbyBuild(
 ) {
   return new Promise((resolve, reject) => {
     const cp = fork(
-      join(workspaceRoot, './node_modules/gatsby-cli/lib/index.js'),
+      require.resolve('gatsby-cli'),
       ['build', ...createGatsbyBuildOptions(options)],
       {
         cwd: join(workspaceRoot, projectRoot),

--- a/packages/gatsby-plugin/src/builders/server/builder.ts
+++ b/packages/gatsby-plugin/src/builders/server/builder.ts
@@ -80,17 +80,13 @@ function createGatsbyOptions(options) {
 
 async function runGatsbyDevelop(workspaceRoot, projectRoot, options) {
   return new Promise<boolean>((resolve, reject) => {
-    const cp = fork(
-      join(workspaceRoot, './node_modules/gatsby-cli/lib/index.js'),
-      ['develop', ...options],
-      {
-        cwd: join(workspaceRoot, projectRoot),
-        env: {
-          ...process.env,
-        },
-        stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
-      }
-    );
+    const cp = fork(require.resolve('gatsby-cli'), ['develop', ...options], {
+      cwd: join(workspaceRoot, projectRoot),
+      env: {
+        ...process.env,
+      },
+      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+    });
 
     // Ensure the child process is killed when the parent exits
     process.on('exit', () => cp.kill());
@@ -124,7 +120,7 @@ function runGatsbyServe(
 ) {
   return new Promise((resolve, reject) => {
     const cp = fork(
-      join(workspaceRoot, './node_modules/gatsby-cli/lib/index.js'),
+      require.resolve('gatsby-cli'),
       ['serve', ...createGatsbyServeOptions(options)],
       { cwd: join(workspaceRoot, projectRoot) }
     );


### PR DESCRIPTION
This restores a fix that appears to have been blown away a later merge.